### PR TITLE
Fix some header issues & implement `uadd8`, `sel`

### DIFF
--- a/src/core/arm11/gpu.cpp
+++ b/src/core/arm11/gpu.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include "gpu.hpp"

--- a/src/core/arm11/wifi.cpp
+++ b/src/core/arm11/wifi.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "../common/common.hpp"
 #include "../corelink_dma.hpp"
 #include "wifi.hpp"

--- a/src/core/corelink_dma.cpp
+++ b/src/core/corelink_dma.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "common/common.hpp"
 #include "corelink_dma.hpp"
 

--- a/src/core/cpu/arm.cpp
+++ b/src/core/cpu/arm.cpp
@@ -17,6 +17,8 @@ uint32_t PSR_Flags::get()
     reg |= carry << 29;
     reg |= overflow << 28;
     reg |= q_overflow << 27;
+    for (int i = 0; i < 4; i++)
+        reg |= ge[i] << (16 + i);
 
     reg |= irq_disable << 7;
     reg |= fiq_disable << 6;
@@ -33,6 +35,8 @@ void PSR_Flags::set(uint32_t value)
     carry = value & (1 << 29);
     overflow = value & (1 << 28);
     q_overflow = value & (1 << 27);
+    for (int i = 0; i < 4; i++)
+        ge[i] = value & (1 << (16 + i));
 
     irq_disable = value & (1 << 7);
     fiq_disable = value & (1 << 6);

--- a/src/core/cpu/arm.hpp
+++ b/src/core/cpu/arm.hpp
@@ -36,6 +36,7 @@ struct PSR_Flags
     bool carry;
     bool overflow;
     bool q_overflow;
+    bool ge[4];
 
     uint32_t get();
     void set(uint32_t value);

--- a/src/core/cpu/arm_disasm.cpp
+++ b/src/core/cpu/arm_disasm.cpp
@@ -110,6 +110,12 @@ ARM_INSTR decode_arm(uint32_t instr)
         if ((instr & 0x0FE00030) == 0x06A00010)
             return ARM_SSAT;
 
+        if ((instr & 0x0FF00FF0) == 0x06800FB0)
+            return ARM_SEL;
+
+        if ((instr & 0x0FF00FF0) == 0x06500F90)
+            return ARM_UADD8;
+
         if ((instr & 0x0FF00F00) == 0x06600F00)
         {
             switch (instr & 0xF0)
@@ -356,6 +362,9 @@ string disasm_arm(ARM_CPU& cpu, uint32_t instr)
         case ARM_LOAD_BLOCK:
         case ARM_STORE_BLOCK:
             return arm_load_store_block(instr);
+        case ARM_SEL:
+            return arm_sel(instr);
+        case ARM_UADD8:
         case ARM_UQSUB8:
             return arm_unsigned_parallel_alu(instr);
         case ARM_COP_LOAD_STORE:
@@ -1521,6 +1530,21 @@ string arm_load_store_block(uint32_t instr)
     return output.str();
 }
 
+string arm_sel(uint32_t instr)
+{
+    stringstream output;
+
+    int reg1 = (instr >> 16) & 0xF;
+    int dest = (instr >> 12) & 0xF;
+    int reg2 = instr & 0xF;
+
+    output << "sel" << cond_name(instr >> 28) << " ";
+    output << ARM_CPU::get_reg_name(dest) << ", " << ARM_CPU::get_reg_name(reg1) << ", " <<
+              ARM_CPU::get_reg_name(reg2);
+
+    return output.str();
+}
+
 string arm_unsigned_parallel_alu(uint32_t instr)
 {
     stringstream output;
@@ -1531,6 +1555,9 @@ string arm_unsigned_parallel_alu(uint32_t instr)
 
     switch (instr & 0xF0)
     {
+        case 0x90:
+            output << "uadd8";
+            break;
         case 0xF0:
             output << "uqsub8";
             break;

--- a/src/core/cpu/arm_disasm.hpp
+++ b/src/core/cpu/arm_disasm.hpp
@@ -46,6 +46,8 @@ enum ARM_INSTR
     ARM_STORE_BLOCK,
     ARM_LOAD_BLOCK,
 
+    ARM_SEL,
+    ARM_UADD8,
     ARM_UQSUB8,
 
     ARM_LOAD_EX_BYTE,
@@ -153,6 +155,7 @@ namespace ARM_Disasm
     std::string arm_mul_long(uint32_t instr);
     std::string arm_mrs(uint32_t instr);
     std::string arm_msr(uint32_t instr);
+    std::string arm_sel(uint32_t instr);
     std::string arm_signed_parallel_alu(uint32_t instr);
     std::string arm_unsigned_parallel_alu(uint32_t instr);
     std::string arm_load_store(ARM_CPU& cpu, uint32_t instr);

--- a/src/core/cpu/arm_interpret.hpp
+++ b/src/core/cpu/arm_interpret.hpp
@@ -29,6 +29,8 @@ namespace ARM_Interpreter
     void arm_ssat(ARM_CPU& cpu, uint32_t instr);
     void arm_data_processing(ARM_CPU& cpu, uint32_t instr);
     void arm_signed_halfword_multiply(ARM_CPU& cpu, uint32_t instr);
+    void arm_sel(ARM_CPU &cpu, uint32_t instr);
+    void arm_uadd8(ARM_CPU &cpu, uint32_t instr);
     void arm_uqsub8(ARM_CPU& cpu, uint32_t instr);
     void arm_mul(ARM_CPU& cpu, uint32_t instr);
     void arm_mul_long(ARM_CPU& cpu, uint32_t instr);


### PR DESCRIPTION
`uadd8` and `sel` were required by the fastboot3DS build I have on my NAND dump.