### PR TITLE
EXPERIMENTAL: New3DS support

### DIFF
--- a/src/core/arm11/dsp.cpp
+++ b/src/core/arm11/dsp.cpp
@@ -238,7 +238,7 @@ uint16_t DSP::read16(uint32_t addr)
             //printf("[DSP_CPU] Read16 PSTS: $%04X\n", reg);
             break;
         case 0x10203010:
-            //TODO: Is SET_SEMA readable?
+            reg = apbp.dsp_sema_recv;
             break;
         case 0x10203014:
             reg = apbp.cpu_sema_mask;
@@ -2321,7 +2321,7 @@ void DSP::assert_dsp_irq(int id)
 
 void DSP::int_check()
 {
-    if (mod3.master_int_enable)
+    if (mod3.master_int_enable && !rep)
     {
         bool irq_found = false;
         for (int id = 0; id < 16; id++)

--- a/src/core/arm11/gpu.cpp
+++ b/src/core/arm11/gpu.cpp
@@ -3913,7 +3913,8 @@ void GPU::write32(uint32_t addr, uint32_t value)
 
                     //TODO: How long does a memfill take? We just assume a constant value for now
                     uint32_t cycles = memfill[index].end - memfill[index].start;
-                    scheduler->add_event([this](uint64_t param) { this->do_memfill(param);}, cycles, index);
+                    scheduler->add_event([this](uint64_t param) { this->do_memfill(param);}, cycles,
+                            ARM11_CLOCKRATE, index);
                 }
                 break;
         }
@@ -3957,7 +3958,8 @@ void GPU::write32(uint32_t addr, uint32_t value)
             {
                 dma.busy = true;
                 dma.finished = false;
-                scheduler->add_event([this](uint64_t param) { this->do_transfer_engine_dma(param);}, 1000);
+                scheduler->add_event([this](uint64_t param) { this->do_transfer_engine_dma(param);},
+                    ARM11_CLOCKRATE, 1000);
             }
             break;
         case 0x0C20:
@@ -3987,7 +3989,8 @@ void GPU::write32(uint32_t addr, uint32_t value)
             if (value & 0x1)
             {
                 cmd_engine.busy = true;
-                scheduler->add_event([this](uint64_t param) { this->do_command_engine_dma(param);}, cmd_engine.size);
+                scheduler->add_event([this](uint64_t param) { this->do_command_engine_dma(param);},
+                    ARM11_CLOCKRATE, cmd_engine.size);
             }
             break;
         default:

--- a/src/core/arm11/gpu.cpp
+++ b/src/core/arm11/gpu.cpp
@@ -3959,7 +3959,7 @@ void GPU::write32(uint32_t addr, uint32_t value)
                 dma.busy = true;
                 dma.finished = false;
                 scheduler->add_event([this](uint64_t param) { this->do_transfer_engine_dma(param);},
-                    ARM11_CLOCKRATE, 1000);
+                    1000, ARM11_CLOCKRATE);
             }
             break;
         case 0x0C20:
@@ -3990,7 +3990,7 @@ void GPU::write32(uint32_t addr, uint32_t value)
             {
                 cmd_engine.busy = true;
                 scheduler->add_event([this](uint64_t param) { this->do_command_engine_dma(param);},
-                    ARM11_CLOCKRATE, cmd_engine.size);
+                    cmd_engine.size, ARM11_CLOCKRATE);
             }
             break;
         default:

--- a/src/core/arm11/mpcore_pmr.cpp
+++ b/src/core/arm11/mpcore_pmr.cpp
@@ -244,7 +244,6 @@ uint32_t MPCore_PMR::read32(int core, uint32_t addr)
     switch (addr)
     {
         case 0x17E00004:
-            printf("[PMR%d] Read SCU_CONFIG\n", core);
             return (core_count - 1) | (0xF << 4);
         case 0x17E0010C:
         {

--- a/src/core/arm11/mpcore_pmr.cpp
+++ b/src/core/arm11/mpcore_pmr.cpp
@@ -5,14 +5,15 @@
 #include "../timers.hpp"
 #include "mpcore_pmr.hpp"
 
-MPCore_PMR::MPCore_PMR(ARM_CPU* appcore, ARM_CPU* syscore, Timers* timers) :
-    appcore(appcore), syscore(syscore), timers(timers)
+MPCore_PMR::MPCore_PMR(ARM_CPU arm11[4], Timers* timers) :
+    arm11(arm11), timers(timers)
 {
 
 }
 
-void MPCore_PMR::reset()
+void MPCore_PMR::reset(int core_count)
 {
+    this->core_count = core_count;
     //No interrupt pending
     for (int i = 0; i < 4; i++)
     {
@@ -39,8 +40,7 @@ void MPCore_PMR::assert_hw_irq(int id)
 
     uint8_t cpu_targets = global_int_targets[id - 32];
 
-    //2 cores
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < core_count; i++)
     {
         //Only set the interrupt to pending if the core is in the target list
         if (cpu_targets & (1 << i))
@@ -186,10 +186,7 @@ uint32_t MPCore_PMR::read32(int core, uint32_t addr)
                 return timers->arm11_get_load(timer_id);
             case 0x04:
             case 0x24:
-                //2 cores
-                if (core == 0)
-                    return timers->arm11_get_counter(timer_id, appcore->get_cycles_ran());
-                return timers->arm11_get_counter(timer_id, syscore->get_cycles_ran());
+                return timers->arm11_get_counter(timer_id, arm11[core].get_cycles_ran());
             case 0x08:
             case 0x28:
                 return timers->arm11_get_control(timer_id);
@@ -230,17 +227,25 @@ uint32_t MPCore_PMR::read32(int core, uint32_t addr)
         if (addr == 0x17E0181C)
         {
             //29-31 are always 1. 0-28 are always 0 (as they are SWIs)
-            //2 cores
-            if (core == 0)
-                return 0x01010100;
-            return 0x02020200;
+            switch (core)
+            {
+                case 0:
+                    return 0x01010100;
+                case 1:
+                    return 0x02020200;
+                case 2:
+                    return 0x04040400;
+                case 3:
+                    return 0x08080800;
+            }
         }
         return 0;
     }
     switch (addr)
     {
         case 0x17E00004:
-            return 1 | (3 << 4); //2 cores
+            printf("[PMR%d] Read SCU_CONFIG\n", core);
+            return (core_count - 1) | (0xF << 4);
         case 0x17E0010C:
         {
             //Reading returns the cause of the IRQ and acknowledges it
@@ -257,8 +262,7 @@ uint32_t MPCore_PMR::read32(int core, uint32_t addr)
         case 0x17E00118:
             return local_irq_ctrl[core].highest_priority_pending;
         case 0x17E01004:
-            //2 cores + 96 external interrupt lines
-            return (1 << 5) | 0x3;
+            return ((core_count - 1) << 5) | 0x3;
     }
     printf("[PMR%d] Unrecognized read32 $%08X\n", core, addr);
     return 0;
@@ -275,8 +279,7 @@ void MPCore_PMR::write8(int core, uint32_t addr, uint8_t value)
         else
             global_int_priority[addr - 0x17E01420] = value >> 4;
 
-        //2 cores
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < core_count; i++)
             check_if_can_assert_irq(i);
         return;
     }
@@ -338,8 +341,7 @@ void MPCore_PMR::write32(int core, uint32_t addr, uint32_t value)
         int index = (addr / 4) & 0x7;
         global_int_mask[index] |= value;
 
-        //2 cores
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < core_count; i++)
             check_if_can_assert_irq(i);
         return;
     }
@@ -350,8 +352,7 @@ void MPCore_PMR::write32(int core, uint32_t addr, uint32_t value)
         global_int_mask[index] &= ~value;
         global_int_mask[0] |= 0xFFFF;
 
-        //2 cores
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < core_count; i++)
             check_if_can_assert_irq(i);
         return;
     }
@@ -369,8 +370,7 @@ void MPCore_PMR::write32(int core, uint32_t addr, uint32_t value)
                 private_int_pending[i][index] &= ~value;
         }
 
-        //2 cores
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < core_count; i++)
             check_if_can_assert_irq(i);
         return;
     }
@@ -406,7 +406,7 @@ void MPCore_PMR::write32(int core, uint32_t addr, uint32_t value)
         }
             return;
         case 0x17E01F00:
-            //printf("[PMR%d] Send SWI: $%08X\n", core, value);
+            printf("[PMR%d] Send SWI: $%08X\n", core, value);
         {
             uint32_t int_id = value & 0x3FF;
             if (int_id < 32)
@@ -417,7 +417,7 @@ void MPCore_PMR::write32(int core, uint32_t addr, uint32_t value)
                 {
                     case 0:
                         //Send to CPUs within target list
-                        for (int i = 0; i < 2; i++)
+                        for (int i = 0; i < core_count; i++)
                         {
                             if (target_list & (1 << i))
                                 set_pending_irq(i, int_id, core);
@@ -425,7 +425,7 @@ void MPCore_PMR::write32(int core, uint32_t addr, uint32_t value)
                         break;
                     case 1:
                         //Send to all CPUs except the sender
-                        for (int i = 0; i < 2; i++)
+                        for (int i = 0; i < core_count; i++)
                         {
                             if (core != i)
                                 set_pending_irq(i, int_id, core);
@@ -443,15 +443,5 @@ void MPCore_PMR::write32(int core, uint32_t addr, uint32_t value)
 
 void MPCore_PMR::set_int_signal(int core, bool irq)
 {
-    switch (core)
-    {
-        case 0:
-            appcore->set_int_signal(irq);
-            break;
-        case 1:
-            syscore->set_int_signal(irq);
-            break;
-        default:
-            EmuException::die("[PMR] Core%d not implemented for set_int_signal\n", core);
-    }
+    arm11[core].set_int_signal(irq);
 }

--- a/src/core/arm11/mpcore_pmr.hpp
+++ b/src/core/arm11/mpcore_pmr.hpp
@@ -18,7 +18,8 @@ struct LocalIrqController
 class MPCore_PMR
 {
     private:
-        ARM_CPU *appcore, *syscore;
+        ARM_CPU* arm11;
+        int core_count;
         Timers* timers;
         LocalIrqController local_irq_ctrl[4];
 
@@ -40,9 +41,9 @@ class MPCore_PMR
         void set_int_signal(int core, bool irq);
     public:
         constexpr static uint32_t SPURIOUS_INT = 0x3FF;
-        MPCore_PMR(ARM_CPU* appcore, ARM_CPU* syscore, Timers* timers);
+        MPCore_PMR(ARM_CPU arm11[4], Timers* timers);
 
-        void reset();
+        void reset(int core_count);
         void assert_hw_irq(int id);
         void set_pending_irq(int core, int int_id, int id_of_requester = 0);
 

--- a/src/core/arm11/wifi.cpp
+++ b/src/core/arm11/wifi.cpp
@@ -867,7 +867,7 @@ void WiFi::do_wmi_cmd()
                 printf("hey\n");
             };
 
-            scheduler->add_event(blorp, 5000000);
+            scheduler->add_event(blorp, XTENSA_CLOCKRATE, 500000);
 
             printf("[WiFi] WMI_SYNCHRONIZE\n");
         }

--- a/src/core/arm11/wifi.cpp
+++ b/src/core/arm11/wifi.cpp
@@ -867,7 +867,7 @@ void WiFi::do_wmi_cmd()
                 printf("hey\n");
             };
 
-            scheduler->add_event(blorp, XTENSA_CLOCKRATE, 500000);
+            scheduler->add_event(blorp, 500000, XTENSA_CLOCKRATE);
 
             printf("[WiFi] WMI_SYNCHRONIZE\n");
         }

--- a/src/core/arm9/dma9.cpp
+++ b/src/core/arm9/dma9.cpp
@@ -51,6 +51,7 @@ void DMA9::try_ndma_transfer(NDMA_Request req)
     scheduler->add_event(
                 [this](uint64_t param) { this->try_ndma_transfer_event((NDMA_Request)param); },
                 1,
+                ARM9_CLOCKRATE,
                 (uint64_t)req
                 );
 }

--- a/src/core/arm9/emmc.cpp
+++ b/src/core/arm9/emmc.cpp
@@ -105,6 +105,21 @@ bool EMMC::parse_essentials(uint8_t *otp)
     return false;
 }
 
+bool EMMC::is_n3ds()
+{
+    //Read the partition crypt types at 0x118-0x120. If one of them is 0x3, this is a New3DS NAND.
+    char sector[0x200];
+    nand.seekg(0);
+    nand.read((char*)sector, 0x200);
+
+    for (int i = 0x118; i < 0x120; i++)
+    {
+        if (sector[i] == 0x3)
+            return true;
+    }
+    return false;
+}
+
 uint16_t EMMC::read16(uint32_t addr)
 {
     uint16_t reg = 0;

--- a/src/core/arm9/emmc.hpp
+++ b/src/core/arm9/emmc.hpp
@@ -94,6 +94,7 @@ class EMMC
         bool mount_nand(std::string file_name);
         bool mount_sd(std::string file_name);
         bool parse_essentials(uint8_t* otp);
+        bool is_n3ds();
         void reset();
 
         uint16_t read16(uint32_t addr);

--- a/src/core/cpu/arm.cpp
+++ b/src/core/cpu/arm.cpp
@@ -110,9 +110,8 @@ void ARM_CPU::run(int cycles)
 
     try
     {
-        int cycles_to_run = cycles;
         cycles_ran = 0;
-        while (!halted && cycles_to_run)
+        while (!halted && cycles_ran < cycles)
         {
             if (CPSR.thumb)
             {
@@ -145,7 +144,6 @@ void ARM_CPU::run(int cycles)
                 ARM_Interpreter::interpret_arm(*this, instr);
             }
             cycles_ran++;
-            cycles_to_run--;
         }
     }
     catch (EmuException::ARMDataAbort& a)
@@ -189,7 +187,7 @@ void ARM_CPU::jp(uint32_t addr, bool change_thumb_state)
     {
         //can_disassemble = true;
         uint32_t process_ptr = read32(0xFFFF9004);
-        uint32_t pid = read32(process_ptr + 0xB4);
+        uint32_t pid = read32(process_ptr + 0xB4 + 8);
 
         bool main_thread = read32(0xFFFF9000) == read32(process_ptr + 192);
         printf("Jumping to PID%d (main_thread:%d, addr: $%08X)\n", pid, main_thread, addr);
@@ -208,7 +206,7 @@ void ARM_CPU::jp(uint32_t addr, bool change_thumb_state)
                    printf("Error: $%08X\n", gpr[0]);
             }
         }
-        if (pid == 40)
+        if (pid == 7)
         {
             //can_disassemble = true;
 
@@ -305,14 +303,14 @@ void ARM_CPU::swi()
     {
         //uint32_t process_ptr = read32(0xFFFF9004);
         //printf("SVC $%02X, PID%d\n", op, read32(process_ptr + 0xB4));
-        printf("SVC $%02X!\n", op);
+        printf("[ARM%d] SVC $%02X!\n", id, op);
         //printf("SVC $%04X!\n", gpr[7]);
         if (op == 0x32)
         {
             uint32_t tls = cp15->mrc(0, 0xD, 0x3, 0x0);
             uint32_t header = read32(tls + 0x80);
             uint32_t process_ptr = read32(0xFFFF9004);
-            uint32_t pid = read32(process_ptr + 0xB4);
+            uint32_t pid = read32(process_ptr + 0xB4 + 8);
             printf("(PID%d) SendSyncRequest: $%08X\n", pid, header);
         }
     }

--- a/src/core/cpu/arm.hpp
+++ b/src/core/cpu/arm.hpp
@@ -84,6 +84,7 @@ class ARM_CPU
         void print_state();
         int get_id();
         int get_cycles_ran();
+        void inc_cycle_count(int delta);
 
         bool is_halted();
         uint32_t get_PC();
@@ -182,6 +183,11 @@ inline int ARM_CPU::get_id()
 inline int ARM_CPU::get_cycles_ran()
 {
     return cycles_ran;
+}
+
+inline void ARM_CPU::inc_cycle_count(int delta)
+{
+    cycles_ran += delta;
 }
 
 inline uint32_t ARM_CPU::get_register(int id)

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -194,9 +194,9 @@ void Emulator::run()
 
     //VBLANK start and end interrupts
     scheduler.add_event([this](uint64_t param) {mpcore_pmr.assert_hw_irq(0x2A); gpu.render_frame();},
-        ARM11_CLOCKRATE, 4000000);
+        4000000, ARM11_CLOCKRATE);
     scheduler.add_event([this](uint64_t param) {mpcore_pmr.assert_hw_irq(0x2B);},
-        ARM11_CLOCKRATE, 4400000);
+        4400000, ARM11_CLOCKRATE);
     cartridge.save_check();
     while (cycles < 4400000)
     {

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -490,7 +490,7 @@ uint16_t Emulator::arm9_read16(uint32_t addr)
         case 0x10008004:
             return pxi.read_cnt9();
         case 0x10140FFC:
-            return 0x1; //bit 1 = New3DS (we're only emulating Old3DS for now)
+            return 0x5 | (is_n3ds << 1);
         case 0x10146000:
             return HID_PAD; //bits on = keys not pressed
     }

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -35,6 +35,11 @@ class Emulator
         uint8_t boot9_free[1024 * 64], boot11_free[1024 * 64];
         uint8_t boot9_locked[1024 * 64], boot11_locked[1024 * 64];
 
+        bool is_n3ds;
+        uint32_t fcram_size;
+        uint32_t arm9_ram_size;
+        uint32_t qtm_size;
+
         uint8_t twl_consoleid[8];
 
         uint8_t* arm9_RAM;
@@ -42,6 +47,7 @@ class Emulator
         uint8_t* fcram;
         uint8_t* dsp_mem;
         uint8_t* vram;
+        uint8_t* qtm_ram;
 
         ARM_CPU arm9, appcore, syscore;
         CP15 arm9_cp15, app_cp15, sys_cp15;

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -37,6 +37,10 @@ class Emulator
 
         bool is_n3ds;
         int core_count;
+        uint32_t clock_ctrl;
+        uint32_t boot_overlay_addr;
+        uint8_t boot_ctrl[4];
+
         uint32_t fcram_size;
         uint32_t arm9_ram_size;
         uint32_t qtm_size;

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -36,6 +36,7 @@ class Emulator
         uint8_t boot9_locked[1024 * 64], boot11_locked[1024 * 64];
 
         bool is_n3ds;
+        int core_count;
         uint32_t fcram_size;
         uint32_t arm9_ram_size;
         uint32_t qtm_size;
@@ -49,10 +50,10 @@ class Emulator
         uint8_t* vram;
         uint8_t* qtm_ram;
 
-        ARM_CPU arm9, appcore, syscore;
-        CP15 arm9_cp15, app_cp15, sys_cp15;
-        MMU arm9_pu, app_mmu, sys_mmu;
-        VFP app_vfp, sys_vfp;
+        ARM_CPU arm9, arm11[4];
+        CP15 arm9_cp15, arm11_cp15[4];
+        MMU arm9_pu, arm11_mmu[4];
+        VFP vfp[4];
 
         AES aes;
         Cartridge cartridge;

--- a/src/core/i2c.cpp
+++ b/src/core/i2c.cpp
@@ -97,7 +97,7 @@ void I2C::set_cnt(int id, uint8_t value)
     {
         cnt[id].ack_flag = true;
         cnt[id].busy = true;
-        scheduler->add_event([this](uint64_t param) { this->do_transfer(param);}, 20000, id);
+        scheduler->add_event([this](uint64_t param) { this->do_transfer(param);}, 20000, ARM11_CLOCKRATE, id);
     }
 }
 
@@ -288,7 +288,8 @@ void I2C::write_mcu(uint8_t reg_id, uint8_t value)
             for (int i = 0; i < 6; i++)
             {
                 if (value & (1 << i))
-                    scheduler->add_event([this](uint64_t param) { this->mcu_interrupt(param); }, 1000 * 1000, 24 + i);
+                    scheduler->add_event([this](uint64_t param) { this->mcu_interrupt(param); }, 1000 * 1000,
+                        ARM11_CLOCKRATE, 24 + i);
             }
             break;
         default:

--- a/src/core/scheduler.cpp
+++ b/src/core/scheduler.cpp
@@ -75,6 +75,8 @@ void Scheduler::add_event(std::function<void(uint64_t)> func, int64_t cycles, ui
 
     event.func = func;
     event.time_registered = -1; //TODO
+
+    printf("ADD EVENT: %lld %lld\n", cycles, clockrate);
     event.time_to_run = quantum.count + (cycles * (quantum.clockrate / clockrate));
     event.param = param;
 

--- a/src/core/scheduler.cpp
+++ b/src/core/scheduler.cpp
@@ -12,6 +12,9 @@ void Scheduler::reset()
 
     closest_event_time = 0;
 
+    quantum.count = 0;
+    quantum.remainder = 0;
+
     cycles11.count = 0;
     cycles11.remainder = 0;
 
@@ -24,47 +27,55 @@ void Scheduler::reset()
 
 void Scheduler::calculate_cycles_to_run()
 {
-    const static int MAX_CYCLES = 64;
+    const static int MAX_CYCLES = 256;
 
     cycles11_to_run = 0;
 
-    if (cycles11.count + MAX_CYCLES <= closest_event_time)
-        cycles11_to_run = MAX_CYCLES;
+    int64_t delta = closest_event_time - quantum.count;
+
+    if (quantum.count + MAX_CYCLES <= closest_event_time)
+        delta = MAX_CYCLES;
     else
     {
-        int64_t delta = closest_event_time - cycles11.count;
-        if (delta > 0)
-            cycles11_to_run = delta;
-        else
-            cycles11_to_run = 0;
+        int64_t delta = closest_event_time - quantum.count;
+        if (delta < 0)
+            delta = 0;
     }
 
-    //ARM9 cycles are at half speed
-    cycles9_to_run = cycles11_to_run >> 1;
-    cycles9.remainder += cycles11_to_run & 0x1;
-    if (cycles9.remainder == 2)
+    quantum_cycles = delta;
+
+    cycles11_to_run = delta * cycles11.clockrate / quantum.clockrate;
+    cycles11.remainder = delta * cycles11.clockrate % quantum.clockrate;
+    if (cycles11.remainder >= quantum.clockrate / cycles11.clockrate)
+    {
+        cycles11_to_run++;
+        cycles11.remainder -= quantum.clockrate / cycles11.clockrate;
+    }
+
+    cycles9_to_run = delta * cycles9.clockrate / quantum.clockrate;
+    cycles9.remainder = delta * cycles9.clockrate % quantum.clockrate;
+    if (cycles9.remainder >= quantum.clockrate / cycles9.clockrate)
     {
         cycles9_to_run++;
-        cycles9.remainder = 0;
+        cycles9.remainder -= quantum.clockrate / cycles9.clockrate;
     }
 
-    //The Xtensa runs at 40 MHz on the 3DS. This is approximately 7 times slower than the ARM11
-    xtensa_cycles_to_run = cycles11_to_run / 7;
-    xtensa_cycles.remainder += cycles11_to_run % 7;
-    if (xtensa_cycles.remainder >= 7)
+    xtensa_cycles_to_run = delta * xtensa_cycles.clockrate / quantum.clockrate;
+    xtensa_cycles.remainder = delta * xtensa_cycles.clockrate % quantum.clockrate;
+    if (xtensa_cycles.remainder >= quantum.clockrate / xtensa_cycles.clockrate)
     {
         xtensa_cycles_to_run++;
-        xtensa_cycles.remainder -= 7;
+        xtensa_cycles.remainder -= quantum.clockrate / xtensa_cycles.clockrate;
     }
 }
 
-void Scheduler::add_event(std::function<void(uint64_t)> func, int64_t cycles, uint64_t param)
+void Scheduler::add_event(std::function<void(uint64_t)> func, int64_t cycles, uint64_t clockrate, uint64_t param)
 {
     SchedulerEvent event;
 
     event.func = func;
     event.time_registered = -1; //TODO
-    event.time_to_run = cycles11.count + cycles;
+    event.time_to_run = quantum.count + (cycles * (quantum.clockrate / clockrate));
     event.param = param;
 
     closest_event_time = std::min(event.time_to_run, closest_event_time);
@@ -74,10 +85,11 @@ void Scheduler::add_event(std::function<void(uint64_t)> func, int64_t cycles, ui
 
 void Scheduler::process_events()
 {
+    quantum.count += quantum_cycles;
     cycles11.count += cycles11_to_run;
     cycles9.count += cycles9_to_run;
     xtensa_cycles.count += xtensa_cycles_to_run;
-    if (cycles11.count >= closest_event_time)
+    if (quantum.count >= closest_event_time)
     {
         int64_t new_time = 0x7FFFFFFFULL << 32ULL;
         for (auto it = events.begin(); it != events.end(); )

--- a/src/core/scheduler.cpp
+++ b/src/core/scheduler.cpp
@@ -76,7 +76,6 @@ void Scheduler::add_event(std::function<void(uint64_t)> func, int64_t cycles, ui
     event.func = func;
     event.time_registered = -1; //TODO
 
-    printf("ADD EVENT: %lld %lld\n", cycles, clockrate);
     event.time_to_run = quantum.count + (cycles * (quantum.clockrate / clockrate));
     event.param = param;
 

--- a/src/core/scheduler.hpp
+++ b/src/core/scheduler.hpp
@@ -3,10 +3,16 @@
 #include <functional>
 #include <list>
 
+//List of different frequencies
+constexpr static uint64_t ARM11_CLOCKRATE = 268111856; //268 MHz
+constexpr static uint64_t ARM9_CLOCKRATE = ARM11_CLOCKRATE / 2; //134 MHz
+constexpr static uint64_t XTENSA_CLOCKRATE = 40 * 1000 * 1000; //~40 MHz
+
 struct CycleCount
 {
     int64_t count;
     int64_t remainder;
+    uint64_t clockrate;
 };
 
 struct SchedulerEvent
@@ -24,39 +30,66 @@ class Scheduler
 
         int64_t closest_event_time;
 
+        CycleCount quantum;
         CycleCount cycles11;
         CycleCount cycles9;
         CycleCount xtensa_cycles;
 
-        int cycles11_to_run;
-        int cycles9_to_run;
-        int xtensa_cycles_to_run;
+        int64_t quantum_cycles;
+        int64_t cycles11_to_run;
+        int64_t cycles9_to_run;
+        int64_t xtensa_cycles_to_run;
     public:
         Scheduler();
 
         void calculate_cycles_to_run();
-        int get_cycles11_to_run();
-        int get_cycles9_to_run();
-        int get_xtensa_cycles_to_run();
+        int64_t get_cycles11_to_run();
+        int64_t get_cycles9_to_run();
+        int64_t get_xtensa_cycles_to_run();
         void reset();
 
-        void add_event(std::function<void(uint64_t)> func, int64_t cycles, uint64_t param = 0);
+        void set_quantum_rate(uint64_t clock);
+        void set_clockrate_11(uint64_t clock);
+        void set_clockrate_9(uint64_t clock);
+        void set_clockrate_xtensa(uint64_t clock);
+
+        void add_event(std::function<void(uint64_t)> func, int64_t cycles, uint64_t clockrate, uint64_t param = 0);
         void process_events();
 };
 
-inline int Scheduler::get_cycles11_to_run()
+inline int64_t Scheduler::get_cycles11_to_run()
 {
     return cycles11_to_run;
 }
 
-inline int Scheduler::get_cycles9_to_run()
+inline int64_t Scheduler::get_cycles9_to_run()
 {
     return cycles9_to_run;
 }
 
-inline int Scheduler::get_xtensa_cycles_to_run()
+inline int64_t Scheduler::get_xtensa_cycles_to_run()
 {
     return xtensa_cycles_to_run;
+}
+
+inline void Scheduler::set_quantum_rate(uint64_t clock)
+{
+    quantum.clockrate = clock;
+}
+
+inline void Scheduler::set_clockrate_9(uint64_t clock)
+{
+    cycles9.clockrate = clock;
+}
+
+inline void Scheduler::set_clockrate_11(uint64_t clock)
+{
+    cycles11.clockrate = clock;
+}
+
+inline void Scheduler::set_clockrate_xtensa(uint64_t clock)
+{
+    xtensa_cycles.clockrate = clock;
 }
 
 #endif // SCHEDULER_HPP

--- a/src/core/timers.cpp
+++ b/src/core/timers.cpp
@@ -17,13 +17,13 @@ void Timers::reset()
     memset(arm11_timers, 0, sizeof(arm11_timers));
 }
 
-void Timers::run(int cycles)
+void Timers::run(int cycles11, int cycles9)
 {
     for (int i = 0; i < 4; i++)
     {
         if (arm9_timers[i].enabled && !arm9_timers[i].countup)
         {
-            arm9_timers[i].clocks += cycles >> 1;
+            arm9_timers[i].clocks += cycles9;
             while (arm9_timers[i].clocks >= arm9_timers[i].prescalar)
             {
                 arm9_timers[i].counter++;
@@ -39,7 +39,7 @@ void Timers::run(int cycles)
     {
         if (arm11_timers[i].enabled)
         {
-            arm11_timers[i].clocks += cycles;
+            arm11_timers[i].clocks += cycles11;
             while (arm11_timers[i].enabled && arm11_timers[i].clocks >= arm11_timers[i].prescalar)
             {
                 arm11_timers[i].counter--;
@@ -197,6 +197,7 @@ uint32_t Timers::arm11_get_load(int id)
 uint32_t Timers::arm11_get_counter(int id, int delta)
 {
     uint32_t counter = arm11_timers[id].counter;
+
     if (arm11_timers[id].enabled)
         counter -= delta / arm11_timers[id].prescalar;
     //printf("[Timers] Read ARM11 timer%d counter: $%08X (%d)\n", id, counter, delta);

--- a/src/core/timers.hpp
+++ b/src/core/timers.hpp
@@ -47,7 +47,7 @@ class Timers
         Timers(Interrupt9* int9, MPCore_PMR* pmr, Emulator* e);
 
         void reset();
-        void run(int cycles);
+        void run(int cycles11, int cycles9);
 
         uint16_t arm9_read16(uint32_t addr);
         void arm9_write16(uint32_t addr, uint16_t value);


### PR DESCRIPTION
This PR adds some of the functionality needed to boot New3DS NANDs, including overclocking, additional memory, and the two extra ARM11 cores. Corgi3DS automatically distinguishes between O3DS and N3DS NANDs, and Home Menu is able to successfully boot. Some problems remain, however: in N3DS mode, the extra clock speed breaks timer management in the kernel, which causes softlocks due to the HID's input polling thread freezing. There also seems to be an issue with GSP LCD initialization which greatly slows down emulation - it seems to be polling unimplemented registers (haven't looked into this deeply).

Despite the above issues, I plan on merging this soon due to the scheduler improvements in this PR, and I plan on addressing those issues in a separate PR.