### PR TITLE
Scheduler: Manage CPU run loops

### DIFF
--- a/src/core/cpu/arm.cpp
+++ b/src/core/cpu/arm.cpp
@@ -45,7 +45,8 @@ void PSR_Flags::set(uint32_t value)
     mode = (PSR_MODE)(value & 0x1F);
 }
 
-ARM_CPU::ARM_CPU(Emulator* e, int id, CP15* cp15, VFP* vfp) : e(e), id(id), cp15(cp15), vfp(vfp)
+ARM_CPU::ARM_CPU(Emulator* e, Scheduler* scheduler, int id, CP15* cp15, VFP* vfp) :
+    e(e), scheduler(scheduler), id(id), cp15(cp15), vfp(vfp)
 {
 
 }
@@ -95,24 +96,26 @@ void ARM_CPU::reset()
     prefetch_abort_occurred = false;
     can_disassemble = false;
     event_pending = false;
-    halted = false;
     waiting_for_event = false;
     int_pending = false;
 
     local_exclusive_start = 0;
     local_exclusive_end = 0;
+
+    cur_timestamp = 0;
+
+    registered_sched_id = scheduler->register_cpu([this] (int64_t cycles) { this->run(cycles); },
+        &cur_timestamp, Scheduler::ARM11_CLOCKRATE);
+
+    unhalt();
 }
 
 void ARM_CPU::run(int cycles)
 {
-    if (halted)
-        return;
-
     try
     {
-        int cycles_to_run = cycles;
         cycles_ran = 0;
-        while (!halted && cycles_to_run)
+        while (!halted && cycles > 0)
         {
             if (CPSR.thumb)
             {
@@ -144,8 +147,9 @@ void ARM_CPU::run(int cycles)
                 }
                 ARM_Interpreter::interpret_arm(*this, instr);
             }
+            cur_timestamp++;
             cycles_ran++;
-            cycles_to_run--;
+            cycles--;
         }
     }
     catch (EmuException::ARMDataAbort& a)
@@ -398,11 +402,13 @@ void ARM_CPU::halt()
     {
         //printf("[ARM%d] Halting... $%08X\n", id, CPSR.get());
         halted = true;
+        scheduler->stop_cpu(registered_sched_id);
     }
 }
 
 void ARM_CPU::unhalt()
 {
+    scheduler->activate_cpu(registered_sched_id);
     halted = false;
 }
 

--- a/src/core/cpu/arm.hpp
+++ b/src/core/cpu/arm.hpp
@@ -44,11 +44,13 @@ struct PSR_Flags
 
 class Emulator;
 class VFP;
+class Scheduler;
 
 class ARM_CPU
 {
     private:
         Emulator* e;
+        Scheduler* scheduler;
         int id;
         uint32_t gpr[16];
         bool prefetch_abort_occurred;
@@ -57,7 +59,11 @@ class ARM_CPU
         bool can_disassemble;
         bool int_pending;
         bool event_pending;
+
+        int registered_sched_id;
+
         int cycles_ran;
+        int64_t cur_timestamp;
         uint64_t local_exclusive_start, local_exclusive_end;
 
         CP15* cp15;
@@ -75,7 +81,7 @@ class ARM_CPU
         void fetch_new_instr_ptr(uint32_t addr);
     public:
         static uint64_t global_exclusive_start[4], global_exclusive_end[4];
-        ARM_CPU(Emulator* e, int id, CP15* cp15, VFP* vfp);
+        ARM_CPU(Emulator* e, Scheduler* scheduler, int id, CP15* cp15, VFP* vfp);
 
         static std::string get_reg_name(int id);
 

--- a/src/core/scheduler.cpp
+++ b/src/core/scheduler.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include "scheduler.hpp"
+#include "common/exceptions.hpp"
 
 Scheduler::Scheduler()
 {
@@ -8,7 +9,16 @@ Scheduler::Scheduler()
 
 void Scheduler::reset()
 {
+    cpus.clear();
+    active_cpus.clear();
     events.clear();
+
+    //Reserve an arbitrary number of CPUs. This way, the vector will not move its contents to new memory
+    //and thus make active_cpus point to invalid data when push_back is called on the vector.
+    cpus.reserve(100);
+
+    next_cpu_id = 0;
+    next_cpu_time = 0;
 
     closest_event_time = 0;
 
@@ -58,6 +68,66 @@ void Scheduler::calculate_cycles_to_run()
     }
 }
 
+int Scheduler::register_cpu(std::function<void (int64_t)> func, int64_t *cur_timestamp,
+                             uint64_t clockrate)
+{
+    SchedulerCPU cpu;
+    cpu.run_func = func;
+    cpu.cur_timestamp = cur_timestamp;
+    cpu.clockrate = clockrate;
+    cpu.active = false;
+
+    cpus.push_back(cpu);
+    int id = next_cpu_id;
+    next_cpu_id++;
+    return id;
+}
+
+void Scheduler::stop_cpu(int id)
+{
+    if (id < 0 || id >= cpus.size())
+        EmuException::die("[Scheduler] Invalid CPU id %d given to stop_cpu!", id);
+    if (!cpus[id].active)
+        return;
+
+    //Just set the status bit. The run loop will remove this CPU from the list
+    cpus[id].active = false;
+}
+
+void Scheduler::activate_cpu(int id)
+{
+    if (id < 0 || id >= cpus.size())
+        EmuException::die("[Scheduler] Invalid CPU id %d given to activate_cpu!", id);
+    if (cpus[id].active)
+        return;
+    active_cpus.push_back(&cpus[id]);
+    cpus[id].active = true;
+    *cpus[id].cur_timestamp = next_cpu_time;
+}
+
+void Scheduler::run_cpus()
+{
+    const static int64_t MAX_CYCLES = 64;
+    next_cpu_time = std::min(closest_event_time, next_cpu_time + MAX_CYCLES);
+    for (auto it = active_cpus.begin(); it != active_cpus.end(); )
+    {
+        SchedulerCPU* cpu = *(it);
+        if (cpu->active)
+        {
+            int64_t cycles = (next_cpu_time - *cpu->cur_timestamp) << 8;
+            cycles *= cpu->clockrate;
+            cycles /= ARM11_CLOCKRATE;
+            cpu->run_func(cycles >> 8);
+            it++;
+        }
+        else
+        {
+            //If the CPU had been halted previously, remove it from the active list
+            it = active_cpus.erase(it);
+        }
+    }
+}
+
 void Scheduler::add_event(std::function<void(uint64_t)> func, int64_t cycles, uint64_t param)
 {
     SchedulerEvent event;
@@ -77,7 +147,7 @@ void Scheduler::process_events()
     cycles11.count += cycles11_to_run;
     cycles9.count += cycles9_to_run;
     xtensa_cycles.count += xtensa_cycles_to_run;
-    if (cycles11.count >= closest_event_time)
+    if (next_cpu_time >= closest_event_time)
     {
         int64_t new_time = 0x7FFFFFFFULL << 32ULL;
         for (auto it = events.begin(); it != events.end(); )


### PR DESCRIPTION
Old system has the Emulator object calling the run functions on CPUs manually. This PR has the scheduler manage the CPUs - this will make timing events easier, and it offers a slight optimization as the scheduler can just not run CPUs that are halted.