### PR TITLE
scheduler: add a missing <cstdint> include

### DIFF
--- a/src/core/scheduler.hpp
+++ b/src/core/scheduler.hpp
@@ -1,5 +1,6 @@
 #ifndef SCHEDULER_HPP
 #define SCHEDULER_HPP
+#include <cstdint>
 #include <functional>
 #include <list>
 


### PR DESCRIPTION
Fixes the build on MSYS2.