### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v1
       with:
-        name: Corgi3DS
+        name: Corgi3DS-linux
         path: ./build/Corgi3DS
 
   build-windows:
@@ -45,7 +45,7 @@ jobs:
     # Runs a set of commands using the runners shell\
     - name: Build
       run:
-        docker run -u root -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/corgi3DS burningdaylight/mingw-arch:qt /bin/bash -ex /corgi3DS/.github/workflows/windows_build.sh
+        docker run -u root -v $GITHUB_WORKSPACE:/corgi3DS burningdaylight/mingw-arch:qt /bin/bash -ex /corgi3DS/.github/workflows/windows_build.sh
     
     - name: Upload artifact
       uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,54 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-linux:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a set of commands using the runners shell
+    - name: Build
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install qt5-default qtmultimedia5-dev libgmp-dev cmake -y
+        mkdir build && cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Release
+        make
+
+    
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: Corgi3DS
+        path: ./build/Corgi3DS
+
+  build-windows:
+    # Build for windows
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a set of commands using the runners shell\
+    - name: Build
+      run:
+        docker run -u root -e ENABLE_COMPATIBILITY_REPORTING -v $GITHUB_WORKSPACE:/corgi3DS burningdaylight/mingw-arch:qt /bin/bash -ex /corgi3DS/.github/workflows/windows_build.sh
+    
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: Corgi3DS-windows
+        path: ./build/Corgi3DS.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,16 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 on:
   push:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build-linux:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a set of commands using the runners shell
     - name: Build
       run: |
         sudo apt-get update -y
@@ -34,15 +27,12 @@ jobs:
         path: ./build/Corgi3DS
 
   build-windows:
-    # Build for windows
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a set of commands using the runners shell\
+    # 
     - name: Build
       run:
         docker run -u root -v $GITHUB_WORKSPACE:/corgi3DS burningdaylight/mingw-arch:qt /bin/bash -ex /corgi3DS/.github/workflows/windows_build.sh

--- a/.github/workflows/windows_build.sh
+++ b/.github/workflows/windows_build.sh
@@ -1,0 +1,4 @@
+pacman -S --noconfirm mingw-w64-gmp
+mkdir /corgi3DS/build  && cd /corgi3DS/build
+x86_64-w64-mingw32-cmake .. 
+make


### PR DESCRIPTION
This PR adds CI via Github Actions. 
Currently, builds will be uploaded as artifacts and will be available in the "actions" tab, I decided against uploading the builds to Releases as it will clog up the releases.

Fixes issue #17 

Example run(binaries available under "Artifacts"):-https://github.com/hax0kartik/Corgi3DS/actions/runs/138167872

**Note the binaries aren't static, so users will need to provide the required dlls/ install the necessary packages.**