### PR TITLE
[WIP] UI Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ set(PROJECT Corgi3DS)
 project(${PROJECT})
 set(CMAKE_CXX_STANDARD 14)
 
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
 add_compile_options(-Wall -Wextra)
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
@@ -33,6 +37,9 @@ set(SOURCES
     src/core/arm9/emmc.cpp
     src/core/arm9/interrupt9.cpp
     src/qt/emuwindow.cpp
+    src/qt/emuthread.cpp
+    src/qt/settings.cpp
+    src/qt/settingswindow.cpp
     src/core/i2c.cpp
     src/core/common/exceptions.cpp
     src/core/cpu/mmu.cpp
@@ -96,8 +103,10 @@ set(HEADERS
     src/core/arm11/xtensa_interpreter.hpp
     src/core/arm11/wifi_timers.hpp
     src/core/spi.hpp
+    src/qt/emuthread.hpp
+    src/qt/settings.hpp
+    src/qt/settingswindow.hpp
 )
 
-qt5_wrap_cpp(MOC src/qt/emuwindow.hpp)
 add_executable(${PROJECT} ${SOURCES} ${HEADERS} ${MOC})
 target_link_libraries(${PROJECT} Qt5::Core Qt5::Gui Qt5::Multimedia Qt5::Widgets gmpxx gmp)

--- a/Corgi3DS.pro
+++ b/Corgi3DS.pro
@@ -50,7 +50,9 @@ SOURCES += src/qt/main.cpp \
     src/core/arm11/xtensa.cpp \
     src/core/arm11/xtensa_interpreter.cpp \
     src/core/arm11/wifi_timers.cpp \
-    src/core/spi.cpp
+    src/core/spi.cpp \
+    src/qt/settingswindow.cpp \
+    src/qt/settings.cpp
 
 HEADERS += \
     src/core/emulator.hpp \
@@ -94,7 +96,9 @@ HEADERS += \
     src/core/arm11/xtensa.hpp \
     src/core/arm11/xtensa_interpreter.hpp \
     src/core/arm11/wifi_timers.hpp \
-    src/core/spi.hpp
+    src/core/spi.hpp \
+    src/qt/settingswindow.hpp \
+    src/qt/settings.hpp
 
 INCLUDEPATH += /usr/local/include
 

--- a/Corgi3DS.pro
+++ b/Corgi3DS.pro
@@ -52,7 +52,8 @@ SOURCES += src/qt/main.cpp \
     src/core/arm11/wifi_timers.cpp \
     src/core/spi.cpp \
     src/qt/settingswindow.cpp \
-    src/qt/settings.cpp
+    src/qt/settings.cpp \
+    src/qt/emuthread.cpp
 
 HEADERS += \
     src/core/emulator.hpp \
@@ -98,7 +99,8 @@ HEADERS += \
     src/core/arm11/wifi_timers.hpp \
     src/core/spi.hpp \
     src/qt/settingswindow.hpp \
-    src/qt/settings.hpp
+    src/qt/settings.hpp \
+    src/qt/emuthread.hpp
 
 INCLUDEPATH += /usr/local/include
 

--- a/src/core/arm9/cartridge.cpp
+++ b/src/core/arm9/cartridge.cpp
@@ -57,6 +57,8 @@ void Cartridge::save_check()
 
 bool Cartridge::mount(std::string file_name)
 {
+    if (card.is_open())
+        card.close();
     card.open(file_name, std::ios::ate | std::ios::binary);
 
     cart_id = 0xFFFFFFFF;

--- a/src/core/arm9/emmc.cpp
+++ b/src/core/arm9/emmc.cpp
@@ -57,12 +57,16 @@ void EMMC::reset()
 
 bool EMMC::mount_nand(std::string file_name)
 {
+    if (nand.is_open())
+        nand.close();
     nand.open(file_name, std::ios::binary | std::ios::in | std::ios::out);
     return nand.is_open();
 }
 
 bool EMMC::mount_sd(std::string file_name)
 {
+    if (sd.is_open())
+        sd.close();
     sd.open(file_name, std::ios::binary | std::ios::in | std::ios::out);
     return sd.is_open();
 }

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -983,6 +983,9 @@ uint16_t Emulator::arm11_read16(int core, uint32_t addr)
             return 0x7; //3DS/DS SPI switch
         case 0x10140FFC:
             return 0x5 | (is_n3ds << 1);
+        case 0x10141114:
+        case 0x10141116:
+            return 0;
         case 0x10141300:
             return clock_ctrl;
         case 0x10141304:
@@ -1237,6 +1240,9 @@ void Emulator::arm11_write16(int core, uint32_t addr, uint16_t value)
     switch (addr)
     {
         case 0x101401C0:
+            return;
+        case 0x10141114:
+        case 0x10141116:
             return;
         case 0x10141300:
         {

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -1436,3 +1436,8 @@ void Emulator::clear_touchscreen()
 {
     spi.clear_touchscreen();
 }
+
+void Emulator::power_button()
+{
+    i2c.power_button();
+}

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -1441,3 +1441,8 @@ void Emulator::power_button()
 {
     i2c.power_button();
 }
+
+void Emulator::home_button(bool pressed)
+{
+    i2c.home_button(pressed);
+}

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -149,7 +149,10 @@ void Emulator::reset(bool cold_boot)
     sysprot11 = 0;
 
     if (cold_boot)
+    {
+        frames = 0;
         config_bootenv = 0;
+    }
 
     clock_ctrl = 0;
     config_cardctrl2 = 0;
@@ -195,7 +198,6 @@ void Emulator::reset(bool cold_boot)
 
 void Emulator::run()
 {
-    static int frames = 0;
     i2c.update_time();
     printf("FRAME %d\n", frames);
 

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -133,6 +133,7 @@ class Emulator
         void clear_touchscreen();
 
         void power_button();
+        void home_button(bool pressed);
 };
 
 #endif // EMULATOR_HPP

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -131,6 +131,8 @@ class Emulator
 
         void set_touchscreen(uint16_t x, uint16_t y);
         void clear_touchscreen();
+
+        void power_button();
 };
 
 #endif // EMULATOR_HPP

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -84,6 +84,8 @@ class Emulator
         uint8_t config_cardctrl2;
         int card_reset;
 
+        int frames;
+
         uint8_t dsp_mem_config[16];
 
         uint16_t HID_PAD;

--- a/src/core/i2c.cpp
+++ b/src/core/i2c.cpp
@@ -16,6 +16,7 @@ I2C::I2C(MPCore_PMR* pmr, Scheduler* scheduler) : pmr(pmr), scheduler(scheduler)
 
 void I2C::reset()
 {
+    power_pressed = false;
     memset(cnt, 0, sizeof(cnt));
     memset(devices, 0, sizeof(devices));
     mcu_counter = 0;
@@ -316,4 +317,14 @@ void I2C::write_mcu(uint8_t reg_id, uint8_t value)
         default:
             printf("[I2C_MCU] Unrecognized write register $%02X\n", reg_id);
     }
+}
+
+void I2C::power_button()
+{
+    if (!power_pressed)
+    {
+        mcu_interrupt(0);
+        scheduler->add_event([this](uint64_t param) { mcu_interrupt(1);}, 5, 60);
+    }
+    power_pressed = true;
 }

--- a/src/core/i2c.cpp
+++ b/src/core/i2c.cpp
@@ -328,3 +328,11 @@ void I2C::power_button()
     }
     power_pressed = true;
 }
+
+void I2C::home_button(bool pressed)
+{
+    if (pressed)
+        mcu_interrupt(2);
+    else
+        mcu_interrupt(3);
+}

--- a/src/core/i2c.hpp
+++ b/src/core/i2c.hpp
@@ -66,6 +66,7 @@ class I2C
         void mcu_interrupt(int id);
 
         void power_button();
+        void home_button(bool pressed);
 
         uint8_t read8(uint32_t addr);
         void write8(uint32_t addr, uint8_t value);

--- a/src/core/i2c.hpp
+++ b/src/core/i2c.hpp
@@ -35,6 +35,8 @@ class I2C
 
         uint8_t mcu_time[7];
 
+        bool power_pressed;
+
         int mcu_counter;
         int mcu_7f_pos;
         uint8_t mcu_7f_buf[0x13];
@@ -62,6 +64,8 @@ class I2C
 
         void do_transfer(int id);
         void mcu_interrupt(int id);
+
+        void power_button();
 
         uint8_t read8(uint32_t addr);
         void write8(uint32_t addr, uint8_t value);

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -23,7 +23,6 @@ void EmuThread::run()
         try
         {
             e.run();
-            emit frame_complete(e.get_top_buffer(), e.get_bottom_buffer());
         }
         catch (EmuException::FatalError& error)
         {
@@ -36,6 +35,7 @@ void EmuThread::run()
         {
             e.reset(false);
         }
+        emit frame_complete(e.get_top_buffer(), e.get_bottom_buffer());
     }
 }
 

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -15,8 +15,10 @@ EmuThread::EmuThread()
 
 void EmuThread::run()
 {
+
     while (!quit)
     {
+        old_frametime = chrono::system_clock::now();
         while (!has_frame_settings);
 
         has_frame_settings = false;
@@ -35,7 +37,10 @@ void EmuThread::run()
         {
             e.reset(false);
         }
-        emit frame_complete(e.get_top_buffer(), e.get_bottom_buffer());
+        auto now = chrono::system_clock::now();
+        auto elapsed_time = now - old_frametime;
+        int milliseconds = chrono::duration_cast<chrono::milliseconds>(elapsed_time).count();
+        emit frame_complete(e.get_top_buffer(), e.get_bottom_buffer(), milliseconds);
     }
 }
 

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -1,0 +1,83 @@
+#include <fstream>
+
+#include "emuthread.hpp"
+#include "settings.hpp"
+
+using namespace std;
+
+EmuThread::EmuThread()
+{
+
+}
+
+void EmuThread::run()
+{
+
+}
+
+//Returns true if all settings are parsed correctly, allowing the UI thread to start the emuthread.
+bool EmuThread::boot_emulator(QString cart_path)
+{
+    //This function runs in the UI thread. Hence, it is safe for it to access Settings.
+
+    uint8_t boot9_rom[1024 * 64], boot11_rom[1024 * 64];
+
+    ifstream boot9(Settings::boot9_path.toStdString());
+    if (!boot9.is_open())
+    {
+        emit boot_error(tr("Failed to open ARM9 boot ROM."));
+        return false;
+    }
+
+    boot9.read((char*)&boot9_rom, sizeof(boot9_rom));
+
+    boot9.close();
+
+    ifstream boot11(Settings::boot11_path.toStdString());
+    if (!boot11.is_open())
+    {
+        emit boot_error(tr("Failed to open ARM11 boot ROM."));
+        return false;
+    }
+
+    boot11.read((char*)&boot11_rom, sizeof(boot11_rom));
+
+    boot11.close();
+
+    e.load_roms(boot9_rom, boot11_rom);
+
+    if (!e.mount_nand(Settings::nand_path.toStdString()))
+    {
+        emit boot_error("Failed to load NAND image.");
+        return false;
+    }
+
+    if (!Settings::sd_path.isEmpty())
+    {
+        if (!e.mount_sd(Settings::sd_path.toStdString()))
+        {
+            emit boot_error("Failed to load SD image.");
+            return false;
+        }
+    }
+
+    if (!cart_path.isEmpty())
+    {
+        if (!e.mount_cartridge(cart_path.toStdString()))
+        {
+            emit boot_error("Failed to load 3DS cartridge.");
+            return false;
+        }
+    }
+
+    if (!e.parse_essentials())
+    {
+        emit boot_error("Failed to find OTP and CID. Please make sure your NAND is dumped from the "
+                        "latest version of GodMode9.");
+        return false;
+    }
+
+    e.reset();
+
+    return true;
+}

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -10,12 +10,16 @@ using namespace std;
 EmuThread::EmuThread()
 {
     quit = true;
+    has_frame_settings = false;
 }
 
 void EmuThread::run()
 {
     while (!quit)
     {
+        while (!has_frame_settings);
+
+        has_frame_settings = false;
         try
         {
             e.run();
@@ -101,6 +105,19 @@ bool EmuThread::boot_emulator(QString cart_path)
     e.reset();
 
     quit = false;
+    has_frame_settings = false;
 
     return true;
+}
+
+void EmuThread::pass_frame_settings(FrameSettings *f)
+{
+    e.set_pad(f->pad_state);
+
+    if (f->touchscreen_pressed)
+        e.set_touchscreen(f->touchscreen_x, f->touchscreen_y);
+    else
+        e.clear_touchscreen();
+
+    has_frame_settings = true;
 }

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -119,5 +119,8 @@ void EmuThread::pass_frame_settings(FrameSettings *f)
     else
         e.clear_touchscreen();
 
+    if (f->power_button)
+        e.power_button();
+
     has_frame_settings = true;
 }

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -122,5 +122,11 @@ void EmuThread::pass_frame_settings(FrameSettings *f)
     if (f->power_button)
         e.power_button();
 
+    if (f->home_button ^ f->old_home_button)
+    {
+        f->old_home_button = f->home_button;
+        e.home_button(f->home_button);
+    }
+
     has_frame_settings = true;
 }

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -1,0 +1,23 @@
+#ifndef EMUTHREAD_HPP
+#define EMUTHREAD_HPP
+#include <QString>
+#include <QThread>
+
+#include "../core/emulator.hpp"
+
+class EmuThread : public QThread
+{
+    Q_OBJECT
+    private:
+        Emulator e;
+    public:
+        EmuThread();
+
+        bool boot_emulator(QString cart_path);
+    protected:
+        void run() override;
+    signals:
+        void boot_error(QString message);
+};
+
+#endif // EMUTHREAD_HPP

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -16,6 +16,8 @@ struct FrameSettings
     uint16_t touchscreen_x, touchscreen_y;
 
     bool power_button;
+    bool home_button;
+    bool old_home_button;
 };
 
 class EmuThread : public QThread

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -4,6 +4,7 @@
 #include <QThread>
 
 #include <atomic>
+#include <chrono>
 
 #include "../core/emulator.hpp"
 
@@ -27,6 +28,8 @@ class EmuThread : public QThread
         bool quit;
         std::atomic<bool> has_frame_settings;
         Emulator e;
+
+        std::chrono::system_clock::time_point old_frametime;
     public:
         EmuThread();
 
@@ -35,7 +38,7 @@ class EmuThread : public QThread
         void run() override;
     signals:
         void boot_error(QString message);
-        void frame_complete(uint8_t* top_buffer, uint8_t* bottom_buffer);
+        void frame_complete(uint8_t* top_buffer, uint8_t* bottom_buffer, float msec);
         void emu_error(QString message);
     public slots:
         void pass_frame_settings(FrameSettings* f);

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -14,6 +14,8 @@ struct FrameSettings
 
     bool touchscreen_pressed;
     uint16_t touchscreen_x, touchscreen_y;
+
+    bool power_button;
 };
 
 class EmuThread : public QThread

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -3,13 +3,25 @@
 #include <QString>
 #include <QThread>
 
+#include <atomic>
+
 #include "../core/emulator.hpp"
+
+//The UI thread passes these settings to the emulator at the start of every frame.
+struct FrameSettings
+{
+    uint16_t pad_state;
+
+    bool touchscreen_pressed;
+    uint16_t touchscreen_x, touchscreen_y;
+};
 
 class EmuThread : public QThread
 {
     Q_OBJECT
     private:
         bool quit;
+        std::atomic<bool> has_frame_settings;
         Emulator e;
     public:
         EmuThread();
@@ -21,6 +33,8 @@ class EmuThread : public QThread
         void boot_error(QString message);
         void frame_complete(uint8_t* top_buffer, uint8_t* bottom_buffer);
         void emu_error(QString message);
+    public slots:
+        void pass_frame_settings(FrameSettings* f);
 };
 
 #endif // EMUTHREAD_HPP

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -9,6 +9,7 @@ class EmuThread : public QThread
 {
     Q_OBJECT
     private:
+        bool quit;
         Emulator e;
     public:
         EmuThread();
@@ -18,6 +19,8 @@ class EmuThread : public QThread
         void run() override;
     signals:
         void boot_error(QString message);
+        void frame_complete(uint8_t* top_buffer, uint8_t* bottom_buffer);
+        void emu_error(QString message);
 };
 
 #endif // EMUTHREAD_HPP

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -137,6 +137,9 @@ void EmuWindow::keyPressEvent(QKeyEvent *event)
         case Qt::Key_W:
             press_key(PAD_R);
             break;
+        case Qt::Key_P:
+            frame_settings.power_button = true;
+            break;
         case Qt::Key_Return:
             press_key(PAD_START);
             break;
@@ -226,6 +229,7 @@ void EmuWindow::boot_emulator(QString cart_path)
 {
     if (emuthread.boot_emulator(cart_path))
     {
+        frame_settings.power_button = false;
         emuthread.pass_frame_settings(&frame_settings);
         emuthread.start();
     }

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -238,16 +238,30 @@ void EmuWindow::boot_emulator(QString cart_path)
         frame_settings.power_button = false;
         frame_settings.old_home_button = false;
         frame_settings.home_button = false;
+        for (int i = 0; i < FRAMETIME_COUNT; i++)
+            past_frametimes[i] = 0.0;
+        frametime_index = 0;
         emuthread.pass_frame_settings(&frame_settings);
         emuthread.start();
     }
 }
 
-void EmuWindow::frame_complete(uint8_t *top_screen, uint8_t *bottom_screen)
+void EmuWindow::frame_complete(uint8_t *top_screen, uint8_t *bottom_screen, float msec)
 {
     draw(top_screen, bottom_screen);
 
     emuthread.pass_frame_settings(&frame_settings);
+
+    past_frametimes[frametime_index] = msec;
+    frametime_index = (frametime_index + 1) % FRAMETIME_COUNT;
+
+    float avg = 0.0;
+    for (int i = 0; i < FRAMETIME_COUNT; i++)
+        avg += past_frametimes[i];
+
+    avg /= FRAMETIME_COUNT;
+
+    setWindowTitle(QString("Corgi3DS - %1 ms/f").arg(QString::number(avg, 'f', 1)));
 }
 
 void EmuWindow::display_boot_error(QString message)

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -1,4 +1,7 @@
+#include <QAction>
 #include <QImage>
+#include <QMenu>
+#include <QMenuBar>
 #include <QPainter>
 #include <QPalette>
 #include <QPoint>
@@ -17,6 +20,16 @@ EmuWindow::EmuWindow()
     running = true;
     touchscreen_pressed = false;
     pad_state = 0;
+
+    settings_window = new SettingsWindow;
+
+    auto settings_action = new QAction(tr("&Settings"), this);
+    connect(settings_action, &QAction::triggered, this, [=]() {
+        settings_window->show();
+    });
+
+    auto options_menu = menuBar()->addMenu(tr("&Options"));
+    options_menu->addAction(settings_action);
 }
 
 void EmuWindow::closeEvent(QCloseEvent *event)
@@ -67,6 +80,7 @@ void EmuWindow::keyPressEvent(QKeyEvent *event)
     switch (event->key())
     {
         case Qt::Key_Up:
+            settings_window->show();
             press_key(PAD_UP);
             break;
         case Qt::Key_Down:

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -29,6 +29,8 @@ EmuWindow::EmuWindow()
     init_menu_bar();
 
     connect(&emuthread, &EmuThread::boot_error, this, &EmuWindow::display_boot_error);
+    connect(&emuthread, &EmuThread::frame_complete, this, &EmuWindow::draw);
+    connect(&emuthread, &EmuThread::emu_error, this, &EmuWindow::display_emu_error);
 }
 
 void EmuWindow::init_menu_bar()
@@ -222,10 +224,26 @@ void EmuWindow::release_key(HID_PAD_STATE state)
 
 void EmuWindow::boot_emulator(QString cart_path)
 {
-    emuthread.boot_emulator(cart_path);
+    if (emuthread.boot_emulator(cart_path))
+        emuthread.start();
 }
 
 void EmuWindow::display_boot_error(QString message)
 {
-    QMessageBox::critical(this, tr("Error"), message);
+    QMessageBox msgBox;
+    msgBox.setText("Error occurred during boot");
+    msgBox.setInformativeText(message);
+    msgBox.setStandardButtons(QMessageBox::Abort);
+    msgBox.setDefaultButton(QMessageBox::Abort);
+    msgBox.exec();
+}
+
+void EmuWindow::display_emu_error(QString message)
+{
+    QMessageBox msgBox;
+    msgBox.setText("Emulation has been terminated");
+    msgBox.setInformativeText(message);
+    msgBox.setStandardButtons(QMessageBox::Abort);
+    msgBox.setDefaultButton(QMessageBox::Abort);
+    msgBox.exec();
 }

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -140,6 +140,9 @@ void EmuWindow::keyPressEvent(QKeyEvent *event)
         case Qt::Key_P:
             frame_settings.power_button = true;
             break;
+        case Qt::Key_H:
+            frame_settings.home_button = true;
+            break;
         case Qt::Key_Return:
             press_key(PAD_START);
             break;
@@ -184,6 +187,9 @@ void EmuWindow::keyReleaseEvent(QKeyEvent *event)
             break;
         case Qt::Key_W:
             release_key(PAD_R);
+            break;
+        case Qt::Key_H:
+            frame_settings.home_button = false;
             break;
         case Qt::Key_Return:
             release_key(PAD_START);
@@ -230,6 +236,8 @@ void EmuWindow::boot_emulator(QString cart_path)
     if (emuthread.boot_emulator(cart_path))
     {
         frame_settings.power_button = false;
+        frame_settings.old_home_button = false;
+        frame_settings.home_button = false;
         emuthread.pass_frame_settings(&frame_settings);
         emuthread.start();
     }

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -45,7 +45,6 @@ class EmuWindow : public QMainWindow
         void init_menu_bar();
 
         void draw(uint8_t* top_screen, uint8_t* bottom_screen);
-        void boot_emulator(QString cart_path);
     public:
         EmuWindow();
 
@@ -57,6 +56,8 @@ class EmuWindow : public QMainWindow
         void mouseReleaseEvent(QMouseEvent* event) override;
 
         void paintEvent(QPaintEvent* event) override;
+
+        void boot_emulator(QString cart_path);
     signals:
         void pass_frame_settings(FrameSettings* f);
     public slots:

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -37,6 +37,11 @@ class EmuWindow : public QMainWindow
         bool running;
         QImage top_image, bottom_image;
 
+        //Used for measuring the average frametime
+        constexpr static int FRAMETIME_COUNT = 10;
+        float past_frametimes[FRAMETIME_COUNT];
+        int frametime_index;
+
         FrameSettings frame_settings;
 
         void press_key(HID_PAD_STATE state);
@@ -62,7 +67,7 @@ class EmuWindow : public QMainWindow
         void pass_frame_settings(FrameSettings* f);
     public slots:
         void display_boot_error(QString message);
-        void frame_complete(uint8_t* top_screen, uint8_t* bottom_screen);
+        void frame_complete(uint8_t* top_screen, uint8_t* bottom_screen, float msec);
         void display_emu_error(QString message);
 };
 

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 
+#include "emuthread.hpp"
 #include "settingswindow.hpp"
 
 enum HID_PAD_STATE
@@ -31,6 +32,7 @@ class EmuWindow : public QMainWindow
 {
     Q_OBJECT
     private:
+        EmuThread emuthread;
         SettingsWindow* settings_window;
         bool running;
         QImage top_image, bottom_image;
@@ -42,6 +44,10 @@ class EmuWindow : public QMainWindow
 
         void press_key(HID_PAD_STATE state);
         void release_key(HID_PAD_STATE state);
+
+        void init_menu_bar();
+
+        void boot_emulator(QString cart_path);
     public:
         EmuWindow();
 
@@ -61,6 +67,8 @@ class EmuWindow : public QMainWindow
 
         void draw(uint8_t* top_screen, uint8_t* bottom_screen);
         void paintEvent(QPaintEvent* event) override;
+    public slots:
+        void display_boot_error(QString message);
 };
 
 inline bool EmuWindow::is_running()

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -65,10 +65,11 @@ class EmuWindow : public QMainWindow
         void mousePressEvent(QMouseEvent* event) override;
         void mouseReleaseEvent(QMouseEvent* event) override;
 
-        void draw(uint8_t* top_screen, uint8_t* bottom_screen);
         void paintEvent(QPaintEvent* event) override;
     public slots:
         void display_boot_error(QString message);
+        void draw(uint8_t* top_screen, uint8_t* bottom_screen);
+        void display_emu_error(QString message);
 };
 
 inline bool EmuWindow::is_running()

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -37,16 +37,14 @@ class EmuWindow : public QMainWindow
         bool running;
         QImage top_image, bottom_image;
 
-        uint16_t pad_state;
-
-        bool touchscreen_pressed;
-        uint16_t touchscreen_x, touchscreen_y;
+        FrameSettings frame_settings;
 
         void press_key(HID_PAD_STATE state);
         void release_key(HID_PAD_STATE state);
 
         void init_menu_bar();
 
+        void draw(uint8_t* top_screen, uint8_t* bottom_screen);
         void boot_emulator(QString cart_path);
     public:
         EmuWindow();
@@ -59,9 +57,11 @@ class EmuWindow : public QMainWindow
         void mouseReleaseEvent(QMouseEvent* event) override;
 
         void paintEvent(QPaintEvent* event) override;
+    signals:
+        void pass_frame_settings(FrameSettings* f);
     public slots:
         void display_boot_error(QString message);
-        void draw(uint8_t* top_screen, uint8_t* bottom_screen);
+        void frame_complete(uint8_t* top_screen, uint8_t* bottom_screen);
         void display_emu_error(QString message);
 };
 

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -51,13 +51,6 @@ class EmuWindow : public QMainWindow
     public:
         EmuWindow();
 
-        uint16_t get_pad_state();
-        bool is_running();
-
-        bool is_touchscreen_pressed();
-        uint16_t get_touchscreen_x();
-        uint16_t get_touchscreen_y();
-
         void keyPressEvent(QKeyEvent* event) override;
         void keyReleaseEvent(QKeyEvent* event) override;
         void closeEvent(QCloseEvent* event) override;
@@ -71,30 +64,5 @@ class EmuWindow : public QMainWindow
         void draw(uint8_t* top_screen, uint8_t* bottom_screen);
         void display_emu_error(QString message);
 };
-
-inline bool EmuWindow::is_running()
-{
-    return running;
-}
-
-inline uint16_t EmuWindow::get_pad_state()
-{
-    return pad_state;
-}
-
-inline bool EmuWindow::is_touchscreen_pressed()
-{
-    return touchscreen_pressed;
-}
-
-inline uint16_t EmuWindow::get_touchscreen_x()
-{
-    return touchscreen_x;
-}
-
-inline uint16_t EmuWindow::get_touchscreen_y()
-{
-    return touchscreen_y;
-}
 
 #endif // EMUWINDOW_HPP

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -9,6 +9,8 @@
 
 #include <cstdint>
 
+#include "settingswindow.hpp"
+
 enum HID_PAD_STATE
 {
     PAD_A,
@@ -29,6 +31,7 @@ class EmuWindow : public QMainWindow
 {
     Q_OBJECT
     private:
+        SettingsWindow* settings_window;
         bool running;
         QImage top_image, bottom_image;
 

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -31,6 +31,8 @@ int main(int argc, char** argv)
     QString nand_path = parser.value("nand");
     QString sd_path = parser.value("sd");
 
+    Settings::load();
+
     if (!boot9_path.isEmpty())
         Settings::boot9_path = boot9_path;
 
@@ -48,7 +50,7 @@ int main(int argc, char** argv)
     Settings::save();
     EmuWindow* emuwindow = new EmuWindow();
 
-    QString cart_path = parser.value("cart");
+    QString cart_path = parser.value("autoload");
     if (parser.isSet("autoload-nocart"))
         emuwindow->boot_emulator("");
     else if (!cart_path.isEmpty())

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1,105 +1,60 @@
-#include <fstream>
 #include <QApplication>
-#include "../core/emulator.hpp"
-#include "../core/common/exceptions.hpp"
+#include <QCommandLineOption>
+#include <QCommandLineParser>
 #include "emuwindow.hpp"
+#include "settings.hpp"
 
 using namespace std;
 
 int main(int argc, char** argv)
-{
-    if (argc < 5)
-    {
-        printf("Args: [boot9] [boot11] [NAND] [SD]\n");
-        return 1;
-    }
-
-    /*uint8_t boot9_rom[1024 * 64], boot11_rom[1024 * 64];
-
-    ifstream boot9(argv[1]);
-    if (!boot9.is_open())
-    {
-        printf("Failed to open %s\n", argv[1]);
-        return 1;
-    }
-
-    boot9.read((char*)&boot9_rom, sizeof(boot9_rom));
-
-    boot9.close();
-
-    ifstream boot11(argv[2]);
-    if (!boot11.is_open())
-    {
-        printf("Failed to open %s\n", argv[2]);
-        return 1;
-    }
-
-    boot11.read((char*)&boot11_rom, sizeof(boot11_rom));
-
-    boot11.close();
-
-    Emulator e;
-    if (!e.mount_nand(argv[3]))
-    {
-        printf("Failed to open %s\n", argv[3]);
-        return 1;
-    }
-
-    if (!e.mount_sd(argv[4]))
-    {
-        printf("Failed to open %s\n", argv[4]);
-        return 1;
-    }
-
-    if (argc > 5)
-    {
-        if (!e.mount_cartridge(argv[5]))
-        {
-            printf("Failed to open %s\n", argv[5]);
-            return 1;
-        }
-    }
-
-    printf("All files loaded successfully!\n");
-    e.load_roms(boot9_rom, boot11_rom);
-    e.parse_essentials();
-    if (!e.parse_essentials())
-    {
-        printf("Failed to find OTP and CID in essentials.exefs.\n");
-        printf("Please make sure your NAND is dumped from the latest version of GodMode9.\n");
-        return 1;
-    }
-    e.reset();*/
+{   
     QApplication a(argc, argv);
-    EmuWindow* emuwindow = new EmuWindow();
-    a.exec();
-    /*while (emuwindow->is_running())
+    QApplication::setApplicationName("Corgi3DS");
+
+    QCommandLineParser parser;
+    parser.addHelpOption();
+
+    parser.addOptions(
     {
-        a.processEvents();
-        uint16_t pad = emuwindow->get_pad_state();
-        e.set_pad(pad);
+        {"boot9","Path to the 64 KB ARM9 boot ROM.", "boot9"},
+        {"boot11", "Path to the 64 KB ARM11 boot ROM.", "boot11"},
+        {"nand", "NAND dump. Must be dumped from latest version of GodMode9.", "nand"},
+        {"sd", "SD image dump. Optional, but required for sighaxed NANDs.", "sd"},
+        {"autoload", "3DS cartridge. Starts emulation immediately.", "cart"},
+        {"autoload-nocart", "Starts emulation immediately without a cartridge."}
+    });
 
-        if (emuwindow->is_touchscreen_pressed())
-            e.set_touchscreen(emuwindow->get_touchscreen_x(), emuwindow->get_touchscreen_y());
-        else
-            e.clear_touchscreen();
+    parser.process(a.arguments());
 
-        try
-        {
-            e.run();
-            emuwindow->draw(e.get_top_buffer(), e.get_bottom_buffer());
-        }
-        catch (EmuException::FatalError& error)
-        {
-            e.print_state();
-            printf("Fatal emulation error occurred!\n%s\n", error.what());
-            return 1;
-        }
-        catch (EmuException::RebootException& r)
-        {
-            e.reset(false);
-        }
-    }*/
+    QString boot9_path = parser.value("boot9");
+    QString boot11_path = parser.value("boot11");
+    QString nand_path = parser.value("nand");
+    QString sd_path = parser.value("sd");
+
+    if (!boot9_path.isEmpty())
+        Settings::boot9_path = boot9_path;
+
+    if (!boot11_path.isEmpty())
+        Settings::boot11_path = boot11_path;
+
+    if (!nand_path.isEmpty())
+        Settings::nand_path = nand_path;
+
+    if (!sd_path.isEmpty())
+        Settings::sd_path = sd_path;
+
+    //The order of this is important - we need to save settings before EmuWindow is constructed.
+    //Otherwise, the settings window will have the old settings in the UI.
+    Settings::save();
+    EmuWindow* emuwindow = new EmuWindow();
+
+    QString cart_path = parser.value("cart");
+    if (parser.isSet("autoload-nocart"))
+        emuwindow->boot_emulator("");
+    else if (!cart_path.isEmpty())
+        emuwindow->boot_emulator(cart_path);
+
+    a.exec();
 
     return 0;
 }

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -72,10 +72,11 @@ int main(int argc, char** argv)
     e.reset();*/
     QApplication a(argc, argv);
     EmuWindow* emuwindow = new EmuWindow();
-    while (emuwindow->is_running())
+    a.exec();
+    /*while (emuwindow->is_running())
     {
         a.processEvents();
-        /*uint16_t pad = emuwindow->get_pad_state();
+        uint16_t pad = emuwindow->get_pad_state();
         e.set_pad(pad);
 
         if (emuwindow->is_touchscreen_pressed())
@@ -97,8 +98,8 @@ int main(int argc, char** argv)
         catch (EmuException::RebootException& r)
         {
             e.reset(false);
-        }*/
-    }
+        }
+    }*/
 
     return 0;
 }

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    uint8_t boot9_rom[1024 * 64], boot11_rom[1024 * 64];
+    /*uint8_t boot9_rom[1024 * 64], boot11_rom[1024 * 64];
 
     ifstream boot9(argv[1]);
     if (!boot9.is_open())
@@ -37,9 +37,6 @@ int main(int argc, char** argv)
     boot11.read((char*)&boot11_rom, sizeof(boot11_rom));
 
     boot11.close();
-
-    QApplication a(argc, argv);
-    EmuWindow* emuwindow = new EmuWindow();
 
     Emulator e;
     if (!e.mount_nand(argv[3]))
@@ -72,11 +69,13 @@ int main(int argc, char** argv)
         printf("Please make sure your NAND is dumped from the latest version of GodMode9.\n");
         return 1;
     }
-    e.reset();
+    e.reset();*/
+    QApplication a(argc, argv);
+    EmuWindow* emuwindow = new EmuWindow();
     while (emuwindow->is_running())
     {
         a.processEvents();
-        uint16_t pad = emuwindow->get_pad_state();
+        /*uint16_t pad = emuwindow->get_pad_state();
         e.set_pad(pad);
 
         if (emuwindow->is_touchscreen_pressed())
@@ -98,7 +97,7 @@ int main(int argc, char** argv)
         catch (EmuException::RebootException& r)
         {
             e.reset(false);
-        }
+        }*/
     }
 
     return 0;

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -1,0 +1,32 @@
+#include <QSettings>
+#include "settings.hpp"
+
+QString Settings::boot9_path;
+QString Settings::boot11_path;
+QString Settings::nand_path;
+QString Settings::sd_path;
+
+namespace Settings
+{
+
+void load()
+{
+    QSettings qset("CorgiCorp", "Corgi3DS");
+
+    boot9_path = qset.value("system/boot9", "").toString();
+    boot11_path = qset.value("system/boot11", "").toString();
+    nand_path = qset.value("system/nand", "").toString();
+    sd_path = qset.value("system/sd", "").toString();
+}
+
+void save()
+{
+    QSettings qset("CorgiCorp", "Corgi3DS");
+
+    qset.setValue("system/boot9", boot9_path);
+    qset.setValue("system/boot11", boot11_path);
+    qset.setValue("system/nand", nand_path);
+    qset.setValue("system/sd_path", sd_path);
+}
+
+}

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -26,7 +26,7 @@ void save()
     qset.setValue("system/boot9", boot9_path);
     qset.setValue("system/boot11", boot11_path);
     qset.setValue("system/nand", nand_path);
-    qset.setValue("system/sd_path", sd_path);
+    qset.setValue("system/sd", sd_path);
 }
 
 }

--- a/src/qt/settings.hpp
+++ b/src/qt/settings.hpp
@@ -1,0 +1,19 @@
+#ifndef SETTINGS_HPP
+#define SETTINGS_HPP
+#include <QString>
+
+namespace Settings
+{
+
+//Boot settings - loaded once upon starting an emulator
+extern QString boot9_path;
+extern QString boot11_path;
+extern QString nand_path;
+extern QString sd_path;
+
+void load();
+void save();
+
+}
+
+#endif // SETTINGS_HPP

--- a/src/qt/settingswindow.cpp
+++ b/src/qt/settingswindow.cpp
@@ -1,0 +1,107 @@
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QString>
+#include <QVBoxLayout>
+
+#include "settings.hpp"
+#include "settingswindow.hpp"
+
+SettingsWindow::SettingsWindow(QWidget *parent) : QWidget(parent)
+{
+    setWindowTitle(tr("Settings"));
+
+    Settings::load();
+
+    boot9_info = new QLabel(tr("No ROM selected"));
+    boot11_info = new QLabel(tr("No ROM selected"));
+    nand_info = new QLabel(tr("No image selected"));
+    sd_info = new QLabel(tr("No image selected"));
+
+    settings_update();
+
+    QPushButton* boot9_button = new QPushButton(tr("Browse..."));
+    QPushButton* boot11_button = new QPushButton(tr("Browse..."));
+    QPushButton* nand_button = new QPushButton(tr("Browse..."));
+    QPushButton* sd_button = new QPushButton(tr("Browse..."));
+
+    connect(boot9_button, &QPushButton::pressed, this, [=]() {
+        QString file_name = QFileDialog::getOpenFileName(this, tr("Open ARM9 boot ROM"), "", "Binary file (*.bin)");
+        Settings::boot9_path = file_name;
+        printf("Boot9: %s\n", Settings::boot9_path.toStdString().c_str());
+        settings_update();
+    });
+
+    connect(boot11_button, &QPushButton::pressed, this, [=]() {
+        QString file_name = QFileDialog::getOpenFileName(this, tr("Open ARM11 boot ROM"), "", "Binary file (*.bin)");
+        Settings::boot11_path = file_name;
+        settings_update();
+    });
+
+    connect(nand_button, &QPushButton::pressed, this, [=] {
+        QString file_name = QFileDialog::getOpenFileName(this, tr("Open NAND Image"), "", "Binary file (*.bin)");
+        Settings::nand_path = file_name;
+        settings_update();
+    });
+
+    connect(sd_button, &QPushButton::pressed, this, [=] {
+        QString file_name = QFileDialog::getOpenFileName(this, tr("Open SD Image"), "", "Binary file (*.bin)");
+        Settings::sd_path = file_name;
+        settings_update();
+    });
+
+    QGridLayout* grid = new QGridLayout;
+    grid->addWidget(new QLabel(tr("ARM9 boot ROM")), 0, 0);
+    grid->addWidget(boot9_info, 0, 1);
+    grid->addWidget(boot9_button, 0, 2);
+
+    grid->addWidget(new QLabel(tr("ARM11 boot ROM")), 1, 0);
+    grid->addWidget(boot11_info, 1, 1);
+    grid->addWidget(boot11_button, 1, 2);
+
+    grid->addWidget(new QLabel(tr("NAND")), 2, 0);
+    grid->addWidget(nand_info, 2, 1);
+    grid->addWidget(nand_button, 2, 2);
+
+    grid->addWidget(new QLabel(tr("SD")), 3, 0);
+    grid->addWidget(sd_info, 3, 1);
+    grid->addWidget(sd_button, 3, 2);
+
+    QGroupBox* system_files_box = new QGroupBox(tr("System Files"));
+    system_files_box->setLayout(grid);
+
+    QVBoxLayout* layout = new QVBoxLayout;
+    layout->addWidget(system_files_box);
+
+    setLayout(layout);
+
+    setMinimumWidth(400);
+}
+
+void SettingsWindow::settings_update()
+{
+    if (!Settings::boot9_path.isEmpty())
+        boot9_info->setText(QFileInfo(Settings::boot9_path).fileName());
+    else
+        boot9_info->setText(tr("No ROM selected"));
+
+    if (!Settings::boot11_path.isEmpty())
+        boot11_info->setText(QFileInfo(Settings::boot11_path).fileName());
+    else
+        boot11_info->setText(tr("No ROM selected"));
+
+    if (!Settings::nand_path.isEmpty())
+        nand_info->setText(QFileInfo(Settings::nand_path).fileName());
+    else
+        nand_info->setText(tr("No image selected"));
+
+    if (!Settings::sd_path.isEmpty())
+        sd_info->setText(QFileInfo(Settings::sd_path).fileName());
+    else
+        sd_info->setText(tr("No image selected"));
+
+    Settings::save();
+}

--- a/src/qt/settingswindow.cpp
+++ b/src/qt/settingswindow.cpp
@@ -48,7 +48,7 @@ SettingsWindow::SettingsWindow(QWidget *parent) : QWidget(parent)
     });
 
     connect(sd_button, &QPushButton::pressed, this, [=] {
-        QString file_name = QFileDialog::getOpenFileName(this, tr("Open SD Image"), "", "Binary file (*.bin)");
+        QString file_name = QFileDialog::getOpenFileName(this, tr("Open SD Image"), "", "");
         Settings::sd_path = file_name;
         settings_update();
     });

--- a/src/qt/settingswindow.hpp
+++ b/src/qt/settingswindow.hpp
@@ -1,0 +1,24 @@
+#ifndef SETTINGSWINDOW_H
+#define SETTINGSWINDOW_H
+
+#include <QLabel>
+#include <QWidget>
+
+class SettingsWindow : public QWidget
+{
+    Q_OBJECT
+    private:
+        QLabel* boot9_info;
+        QLabel* boot11_info;
+        QLabel* nand_info;
+        QLabel* sd_info;
+
+        void settings_update();
+    public:
+        explicit SettingsWindow(QWidget *parent = nullptr);
+    signals:
+
+    public slots:
+};
+
+#endif // SETTINGSWINDOW_H


### PR DESCRIPTION
This PR adds a settings window that allows users to provide system files, such as boot ROMs and NAND images, through the UI. It also pops up a message box whenever a fatal error occurs and stops emulation, rather than crashing the whole program. The emulator can be booted with or without a 3DS cartridge through the menubar. Finally, emulation now runs on a separate thread so that the UI remains responsive even when the emulator lags.

There remains some work to be done. It would be nice to have an FPS counter, for instance, and some of the code needs cleanup. Furthermore, there is the question of what to do with command-line arguments, as they are currently commented out. The best option is likely to just save arguments into the settings.