### PR TITLE
Fix compilation issue due to missing cstdint include in arm_disasm

### DIFF
--- a/src/core/cpu/arm_disasm.hpp
+++ b/src/core/cpu/arm_disasm.hpp
@@ -2,6 +2,7 @@
 #define ARM_DISASM_HPP
 
 #include <string>
+#include <cstdint>
 
 enum ARM_INSTR
 {


### PR DESCRIPTION
Tried to compile the emulator using the described ways and in both cases I got the same bunch of warnings and the question if `#include <cstdint>` is missing in `arm_disasm.hpp`.
And indeed, after adding that, compiling went through on Arch Linux x86_64.